### PR TITLE
Centralize image handling logic

### DIFF
--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -52,7 +52,7 @@ func Connect(dbName string) *gorm.DB {
 	err = db.AutoMigrate(
 		&models.User{},
 		&models.Listing{},
-		&models.ListingImage{},
+		&models.Image{},
 	)
 
 	if err != nil {

--- a/backend/database/seed.go
+++ b/backend/database/seed.go
@@ -14,62 +14,54 @@ import (
 func SeedListings(db *gorm.DB, ctx context.Context, ids []uuid.UUID) error {
 	listings := []*models.Listing{
 		{
-			ID:          1,
 			Title:       "Standing Desk",
 			Description: "Adjustable standing desk, great condition. Perfect for studying.",
 			Price:       85,
 			SellerID:    ids[0],
 		},
 		{
-		  	ID: 2,
-		  	Title: "Mountain Bike",
-		  	Description: "Trek mountain bike, barely used. Includes lock and helmet.",
-		  	Price: 220,
-		  	SellerID: ids[3],
+			Title:       "Mountain Bike",
+			Description: "Trek mountain bike, barely used. Includes lock and helmet.",
+			Price:       220,
+			SellerID:    ids[3],
 		},
 		{
-			ID:          3,
 			Title:       "Organic Chemistry Textbook",
 			Description: "8th edition, no highlights. ISBN 978-0134042282.",
 			Price:       45,
 			SellerID:    ids[2],
 		},
 		{
-			ID:          4,
 			Title:       "27\" Monitor",
 			Description: "Dell 27\" 1440p IPS monitor. Comes with HDMI cable.",
 			Price:       150,
 			SellerID:    ids[3],
 		},
 		{
-			ID:          5,
 			Title:       "Futon Couch",
 			Description: "Foldable futon, dark grey. Great for dorm rooms.",
 			Price:       60,
 			SellerID:    ids[4],
 		},
 		{
-			ID:          6,
 			Title:       "Acoustic Guitar",
 			Description: "Yamaha FG800, excellent sound. Includes gig bag and tuner.",
 			Price:       130,
 			SellerID:    ids[5],
 		},
 		{
-			ID:          7,
 			Title:       "Desk Lamp",
 			Description: "LED desk lamp with USB charging port. 3 brightness levels.",
 			Price:       18,
 			SellerID:    ids[6],
 		},
 		{
-			ID:          8,
 			Title:       "North Face Backpack",
 			Description: "Black Borealis backpack, very spacious. Minor wear.",
 			Price:       40,
 			SellerID:    ids[7],
 		},
-	}	
+	}
 
 	numListings := 80
 	offset := len(listings)
@@ -78,7 +70,6 @@ func SeedListings(db *gorm.DB, ctx context.Context, ids []uuid.UUID) error {
 	for i := range numListings {
 		i += offset
 		listings = append(listings, &models.Listing{
-			ID:          uint(i + 1),
 			Title:       fmt.Sprintf("Product %d", i+1),
 			Description: "This is a sample description for the item.",
 			Price:       float64((20 + i*2)),
@@ -100,10 +91,10 @@ func SeedListings(db *gorm.DB, ctx context.Context, ids []uuid.UUID) error {
 func SeedUsers(db *gorm.DB, ctx context.Context) ([]*models.User, error) {
 	userRequests := []services.CreateUserRequest{
 		{
-			Email: "test@ufl.edu",
-			Password: "password",
+			Email:     "test@ufl.edu",
+			Password:  "password",
 			FirstName: "Test",
-			LastName: "User",
+			LastName:  "User",
 		},
 		{
 			Email:     "jsmack@ufl.edu",

--- a/backend/handlers/image_handler.go
+++ b/backend/handlers/image_handler.go
@@ -1,0 +1,35 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/Jcorrieri/uf-marketplace/backend/services"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type ImageHandler struct {
+	imageService *services.ImageService
+}
+
+func NewImageHandler(s *services.ImageService) *ImageHandler {
+	return &ImageHandler{imageService: s}
+}
+
+// GET /api/images/:imageId
+func (h *ImageHandler) GetImage(c *gin.Context) {
+	imageID, err := uuid.Parse(c.Param("imageId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid image ID"})
+		return
+	}
+
+	img, err := h.imageService.GetImageByID(c.Request.Context(), imageID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Image not found"})
+		return
+	}
+
+	contentType := http.DetectContentType(img.Data)
+	c.Data(http.StatusOK, contentType, img.Data)
+}

--- a/backend/handlers/listing_handler.go
+++ b/backend/handlers/listing_handler.go
@@ -1,12 +1,12 @@
 package handlers
 
 import (
-	"io"
 	"net/http"
 	"strconv"
 
 	"github.com/Jcorrieri/uf-marketplace/backend/models"
 	"github.com/Jcorrieri/uf-marketplace/backend/services"
+	"github.com/Jcorrieri/uf-marketplace/backend/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -95,29 +95,19 @@ func (h *ListingHandler) CreateListing(c *gin.Context) {
 	}
 
 	// Parse multiple image files
-	MAX_IMG_SIZE := 5 * 1024 * 1024
 	form, err := c.MultipartForm()
 	if err == nil && form.File["images"] != nil {
-		for _, fileHeader := range form.File["images"] {
-			if fileHeader.Size > int64(MAX_IMG_SIZE) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Each image must be under 5MB"})
+		for i, fileHeader := range form.File["images"] {
+			data, mimeType, err := utils.ProcessImageFile(fileHeader)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}
-			file, err := fileHeader.Open()
-			if err != nil {
-				continue
-			}
-			data, err := io.ReadAll(file)
-			file.Close()
-			if err != nil {
-				continue
-			}
-			contentType := http.DetectContentType(data)
-			if contentType != "image/jpeg" && contentType != "image/png" {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Only JPEG and PNG images are allowed"})
-				return
-			}
-			listing.Images = append(listing.Images, models.ListingImage{Data: data})
+			listing.Images = append(listing.Images, models.Image{
+				Data:     data,
+				MimeType: mimeType,
+				Position: i,
+			})
 		}
 	}
 
@@ -125,24 +115,6 @@ func (h *ListingHandler) CreateListing(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create listing"})
 		return
 	}
+
 	c.JSON(http.StatusCreated, listing.GetResponse())
-}
-
-// GET /api/listings/images/:imageId
-func (h *ListingHandler) GetListingImage(c *gin.Context) {
-	imageIDStr := c.Param("imageId")
-	imageID, err := strconv.ParseUint(imageIDStr, 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid image ID"})
-		return
-	}
-
-	img, err := h.listingService.GetImageByID(c.Request.Context(), uint(imageID))
-	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Image not found"})
-		return
-	}
-
-	contentType := http.DetectContentType(img.Data)
-	c.Data(http.StatusOK, contentType, img.Data)
 }

--- a/backend/handlers/user_handler.go
+++ b/backend/handlers/user_handler.go
@@ -1,10 +1,10 @@
 package handlers
 
 import (
-	"io"
 	"net/http"
 
 	"github.com/Jcorrieri/uf-marketplace/backend/services"
+	"github.com/Jcorrieri/uf-marketplace/backend/utils"
 	"github.com/google/uuid"
 
 	"github.com/gin-gonic/gin"
@@ -120,59 +120,23 @@ func (h *UserHandler) UploadProfileImage(c *gin.Context) {
 		return
 	}
 
-	file, header, err := c.Request.FormFile("image")
+	fileHeader, err := c.FormFile("image")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "No image provided"})
 		return
 	}
-	defer file.Close()
 
-	MAX_IMG_SIZE := 5 * 1024 * 1024
-	if header.Size > int64(MAX_IMG_SIZE) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Image must be under 5MB"})
-		return
-	}
-
-	data, err := io.ReadAll(file)
+	data, mimeType, err := utils.ProcessImageFile(fileHeader)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read image"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	// Validate content type
-	contentType := http.DetectContentType(data)
-	if contentType != "image/jpeg" && contentType != "image/png" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Only JPEG and PNG images are allowed"})
-		return
-	}
-
-	if err := h.userService.UpdateProfileImage(c.Request.Context(), id, data); err != nil {
+	imageID, err := h.userService.UpdateProfileImage(c.Request.Context(), id, data, mimeType)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save image"})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Profile image updated"})
-}
-
-// GET /api/users/:id/profile-image
-func (h *UserHandler) GetProfileImage(c *gin.Context) {
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
-		return
-	}
-
-	user, err := h.userService.GetByID(c.Request.Context(), id)
-	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
-		return
-	}
-
-	if len(user.ProfileImage) == 0 {
-		c.JSON(http.StatusNotFound, gin.H{"error": "No profile image"})
-		return
-	}
-
-	contentType := http.DetectContentType(user.ProfileImage)
-	c.Data(http.StatusOK, contentType, user.ProfileImage)
+	c.JSON(http.StatusOK, gin.H{"message": "Profile image updated", "image_id": imageID})
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -28,7 +28,6 @@ func RegisterUserRoutes(
 	userHandler *handlers.UserHandler,
 	userService *services.UserService,
 ) {
-	protected.GET("/users/:id/profile-image", userHandler.GetProfileImage)
 	protected.PUT("/users/me/profile-image", userHandler.UploadProfileImage)
 	protected.GET("/users/:id", userHandler.GetUserById)
 	protected.GET("/users/me", userHandler.GetCurrentUser)
@@ -43,8 +42,14 @@ func RegisterListingsRoutes(
 	listingService *services.ListingService,
 ) {
 	public.GET("/listings", listingHandler.GetListings)
-	public.GET("/listings/images/:imageId", listingHandler.GetListingImage)
 	protected.POST("/listings", listingHandler.CreateListing)
+}
+
+func RegisterImageRoutes(
+	public *gin.RouterGroup,
+	imageHandler *handlers.ImageHandler,
+) {
+	public.GET("/images/:imageId", imageHandler.GetImage)
 }
 
 func main() {
@@ -65,11 +70,13 @@ func main() {
 	authService := services.NewAuthService(db)
 	userService := services.NewUserService(db)
 	listingService := services.NewListingService(db)
+	imageService := services.NewImageService(db)
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(authService, userService, sessionName)
 	userHandler := handlers.NewUserHandler(userService)
 	listingHandler := handlers.NewListingHandler(listingService)
+	imageHandler := handlers.NewImageHandler(imageService)
 
 	// Middleware
 	authMiddleware := middleware.AuthMiddleware(os.Getenv("JWT_SECRET"), sessionName)
@@ -85,6 +92,7 @@ func main() {
 	RegisterAuthRoutes(auth, authHandler, authService)
 	RegisterUserRoutes(protected, userHandler, userService)
 	RegisterListingsRoutes(api, protected, listingHandler, listingService)
+	RegisterImageRoutes(api, imageHandler)
 
 	router.Run("localhost:8080")
 }

--- a/backend/models/image.go
+++ b/backend/models/image.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// NOTE: https://gorm.io/docs/polymorphism.html
+type Image struct {
+	ID        uuid.UUID `gorm:"primaryKey"`
+	OwnerID   uuid.UUID `gorm:"not null;index"`
+	OwnerType string    `gorm:"not null;index"` // "listings" or "users"
+	Data      []byte    `gorm:"type:blob;not null"`
+	MimeType  string    `gorm:"not null"`  // "image/jpeg", etc.
+	Position  int       `gorm:"default:0"` // ordering for multi-image listings
+	CreatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+}
+
+// NOTE: https://gorm.io/docs/hooks.html
+func (i *Image) BeforeCreate(tx *gorm.DB) error {
+	id, err := uuid.NewV7()
+	i.ID = id
+	return err
+}

--- a/backend/models/listing.go
+++ b/backend/models/listing.go
@@ -8,40 +8,39 @@ import (
 )
 
 type Listing struct {
-	ID          uint           `json:"id" gorm:"primaryKey"`
-	Title       string         `json:"title"`
-	Description string         `json:"description"`
-	Price       float64        `json:"price"`
-	SellerID    uuid.UUID      `json:"seller_id" gorm:"type:uuid,index"`
-	Seller      User           `json:"-" gorm:"foreignKey:SellerID"`
-	Images      []ListingImage `json:"images" gorm:"foreignKey:ListingID"`
-	CreatedAt   time.Time      `gorm:"index"`
+	ID          uuid.UUID `json:"id" gorm:"primaryKey"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	Price       float64   `json:"price"`
+	SellerID    uuid.UUID `json:"seller_id" gorm:"type:uuid,index"`
+	Seller      User      `json:"-" gorm:"foreignKey:SellerID"`
+	Images      []Image   `json:"images" gorm:"polymorphic:Owner;constraint:OnDelete:CASCADE;"`
+	CreatedAt   time.Time `gorm:"index"`
 	UpdatedAt   time.Time
 	DeletedAt   gorm.DeletedAt `gorm:"index"`
 }
 
-type ListingImage struct {
-	ID        uint   `json:"id" gorm:"primaryKey"`
-	ListingID uint   `json:"listing_id" gorm:"index"`
-	Data      []byte `json:"-" gorm:"type:blob;not null"`
-	CreatedAt time.Time
-	DeletedAt gorm.DeletedAt `gorm:"index"`
+// NOTE: https://gorm.io/docs/hooks.html
+func (l *Listing) BeforeCreate(tx *gorm.DB) error {
+	id, err := uuid.NewV7()
+	l.ID = id
+	return err
 }
 
 type ListingResponse struct {
-	ID           uint      `json:"id"`
-	Title        string    `json:"title"`
-	Description  string    `json:"description"`
-	Price        float64   `json:"price"`
-	ImageCount   int       `json:"image_count"`
-	FirstImageID *uint     `json:"first_image_id"`
-	SellerName   string    `json:"seller_name"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	ID           uuid.UUID  `json:"id"`
+	Title        string     `json:"title"`
+	Description  string     `json:"description"`
+	Price        float64    `json:"price"`
+	ImageCount   int        `json:"image_count"`
+	FirstImageID *uuid.UUID `json:"first_image_id"`
+	SellerName   string     `json:"seller_name"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
 }
 
 func (l *Listing) GetResponse() ListingResponse {
-	var firstImageID *uint
+	var firstImageID *uuid.UUID
 	if len(l.Images) > 0 {
 		firstImageID = &l.Images[0].ID
 	}

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -15,20 +15,10 @@ type User struct {
 	PasswordHash string `json:"-" gorm:"not null"`
 	FirstName    string `gorm:"not null"`
 	LastName     string `gorm:"not null"`
-	ProfileImage []byte `json:"-" gorm:"type:blob"`
+	ProfileImage Image  `json:"image" gorm:"polymorphic:Owner;constraint:OnDelete:CASCADE;"`
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	DeletedAt    gorm.DeletedAt `gorm:"index"`
-}
-
-// The actual JSON object returned by the API
-type UserResponse struct {
-	ID              uuid.UUID `json:"id"`
-	Email           string    `json:"email"`
-	FirstName       string    `json:"first_name"`
-	LastName        string    `json:"last_name"`
-	HasProfileImage bool      `json:"has_profile_image"`
-	CreatedAt       time.Time `json:"created_at"`
 }
 
 // NOTE: https://gorm.io/docs/hooks.html
@@ -38,13 +28,27 @@ func (u *User) BeforeCreate(tx *gorm.DB) error {
 	return err
 }
 
+// The actual JSON object returned by the API
+type UserResponse struct {
+	ID        uuid.UUID  `json:"id"`
+	Email     string     `json:"email"`
+	FirstName string     `json:"first_name"`
+	LastName  string     `json:"last_name"`
+	ImageID   *uuid.UUID `json:"image_id"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
 func (u *User) GetResponse() UserResponse {
+	var imageID *uuid.UUID
+	if u.ProfileImage.ID != uuid.Nil {
+		imageID = &u.ProfileImage.ID
+	}
 	return UserResponse{
-		ID:              u.ID,
-		Email:           u.Email,
-		FirstName:       u.FirstName,
-		LastName:        u.LastName,
-		HasProfileImage: len(u.ProfileImage) > 0,
-		CreatedAt:       u.CreatedAt,
+		ID:        u.ID,
+		Email:     u.Email,
+		FirstName: u.FirstName,
+		LastName:  u.LastName,
+		ImageID:   imageID,
+		CreatedAt: u.CreatedAt,
 	}
 }

--- a/backend/services/image_service.go
+++ b/backend/services/image_service.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+
+	"github.com/Jcorrieri/uf-marketplace/backend/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type ImageService struct {
+	db *gorm.DB
+}
+
+func NewImageService(db *gorm.DB) *ImageService {
+	return &ImageService{db: db}
+}
+
+// Global function to preload only image IDs for listings (users, listings)
+// See https://gorm.io/docs/preload.html
+func ImageIDsOnly(db gorm.PreloadBuilder) error {
+	db.Select("id", "owner_id", "owner_type").Order("position asc")
+	return nil
+}
+
+func (s *ImageService) GetImageByID(ctx context.Context, imageID uuid.UUID) (models.Image, error) {
+	return gorm.G[models.Image](s.db).Where("id = ?", imageID).First(ctx)
+}

--- a/backend/services/listing_service.go
+++ b/backend/services/listing_service.go
@@ -26,10 +26,11 @@ func (s *ListingService) Search(
 
 	queryObj := gorm.G[models.Listing](s.db).
 		Preload("Seller", nil).
+		Preload("Images", ImageIDsOnly).
 		Where(key+" LIKE ?", "%"+query+"%").
 		Order("id DESC").
 		Limit(limit)
-	
+
 	if cursor > 0 {
 		queryObj.Where("id < ?", cursor)
 	}
@@ -46,9 +47,10 @@ func (s *ListingService) GetAll(
 
 	queryObj := gorm.G[models.Listing](s.db).
 		Preload("Seller", nil).
+		Preload("Images", ImageIDsOnly).
 		Order("id DESC").
 		Limit(limit)
-	
+
 	if cursor > 0 {
 		queryObj.Where("id < ?", cursor)
 	}
@@ -58,8 +60,4 @@ func (s *ListingService) GetAll(
 
 func (s *ListingService) Create(ctx context.Context, listing *models.Listing) error {
 	return gorm.G[models.Listing](s.db).Create(ctx, listing)
-}
-
-func (s *ListingService) GetImageByID(ctx context.Context, imageID uint) (models.ListingImage, error) {
-	return gorm.G[models.ListingImage](s.db).Where("id = ?", imageID).First(ctx)
 }

--- a/backend/services/user_service.go
+++ b/backend/services/user_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Jcorrieri/uf-marketplace/backend/models"
 	"github.com/google/uuid"
@@ -25,15 +26,23 @@ func NewUserService(db *gorm.DB) *UserService {
 
 func (s *UserService) GetAll(ctx context.Context) ([]models.User, error) {
 	// Use gorm.G[model.<model>]()... to get built-in type safety
-	return gorm.G[models.User](s.db).Find(ctx)
+	return gorm.G[models.User](s.db).
+		Preload("ProfileImage", ImageIDsOnly).
+		Find(ctx)
 }
 
 func (s *UserService) GetByID(ctx context.Context, id uuid.UUID) (models.User, error) {
-	return gorm.G[models.User](s.db).Where("id = ?", id).First(ctx)
+	return gorm.G[models.User](s.db).
+		Preload("ProfileImage", ImageIDsOnly).
+		Where("id = ?", id).
+		First(ctx)
 }
 
 func (s *UserService) GetByEmail(ctx context.Context, email string) (models.User, error) {
-	return gorm.G[models.User](s.db).Where("email = ?", email).First(ctx)
+	return gorm.G[models.User](s.db).
+		Preload("ProfileImage", ImageIDsOnly).
+		Where("email = ?", email).
+		First(ctx)
 }
 
 type CreateUserRequest struct {
@@ -64,6 +73,7 @@ func (s *UserService) Create(ctx context.Context, request CreateUserRequest) (*m
 	return &user, nil
 }
 
+// TODO: Update to delete images as well
 func (s *UserService) Delete(ctx context.Context, id uuid.UUID) error {
 	// Deleting a record requires some additional processing. Gorm
 	// uses soft deletion by default (see https://gorm.io/docs/delete.html#Soft-Delete).
@@ -119,17 +129,43 @@ func (s *UserService) Update(
 	return &user, nil
 }
 
-func (s *UserService) UpdateProfileImage(ctx context.Context, id uuid.UUID, imageData []byte) error {
-	rows, err := gorm.G[models.User](s.db).
-		Where("id = ?", id).
-		Select("ProfileImage").
-		Updates(ctx, models.User{ProfileImage: imageData})
+func (s *UserService) UpdateProfileImage(
+	ctx context.Context,
+	id uuid.UUID,
+	imageData []byte,
+	mimeType string,
+) (uuid.UUID, error) {
+	image := models.Image{
+		OwnerID:   id,
+		OwnerType: "users",
+		Data:      imageData,
+		MimeType:  mimeType,
+	}
 
-	if err != nil {
-		return err
+	// Check if image already exists
+	existing, err := gorm.G[models.Image](s.db).
+		Where("owner_id = ? AND owner_type = ?", id, "users").
+		First(ctx)
+
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return uuid.Nil, err
 	}
-	if rows == 0 {
-		return gorm.ErrRecordNotFound
+
+	// Image exists
+	if existing.ID != uuid.Nil {
+		_, err := gorm.G[models.Image](s.db).
+			Where("owner_id = ? AND owner_type = ?", id, "users").
+			Updates(ctx, image)
+		if err != nil {
+			return uuid.Nil, err
+		}
+		return existing.ID, nil
 	}
-	return nil
+
+	// Create new
+	if err := gorm.G[models.Image](s.db).Create(ctx, &image); err != nil {
+		return uuid.Nil, err
+	}
+
+	return image.ID, nil
 }

--- a/backend/utils/image.go
+++ b/backend/utils/image.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+)
+
+const MaxImageSize = 5 * 1024 * 1024
+
+func ProcessImageFile(fileHeader *multipart.FileHeader) ([]byte, string, error) {
+	if fileHeader.Size > int64(MaxImageSize) {
+		return nil, "", errors.New("image must be under 5MB")
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		return nil, "", errors.New("failed to open image")
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, "", errors.New("failed to read image")
+	}
+
+	mimeType := http.DetectContentType(data)
+	if mimeType != "image/jpeg" && mimeType != "image/png" {
+		return nil, "", errors.New("only JPEG and PNG images are allowed")
+	}
+
+	return data, mimeType, nil
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -5,6 +5,7 @@ export interface CurrentUser {
   firstName: string;
   lastName: string;
   email: string;
+  image_id?: string | null;
 }
 
 @Injectable({
@@ -22,7 +23,8 @@ export class AuthService {
           id: data.id,
           firstName: data.first_name,
           lastName: data.last_name,
-          email: data.email
+          email: data.email,
+          image_id: data.image_id,
         };
       }
     } catch {

--- a/frontend/src/app/views/main-page/main-page.html
+++ b/frontend/src/app/views/main-page/main-page.html
@@ -48,7 +48,7 @@
     <div class="product-card">
       @if (product.first_image_id) {
         <img
-          [src]="'/api/listings/images/' + product.first_image_id"
+          [src]="'/api/images/' + product.first_image_id"
           [alt]="product.title"
           class="product-image"
         />

--- a/frontend/src/app/views/user-profile-page/user-profile-page.ts
+++ b/frontend/src/app/views/user-profile-page/user-profile-page.ts
@@ -49,11 +49,12 @@ export class UserProfilePage implements OnInit {
           firstName: data.first_name,
           lastName: data.last_name,
           email: data.email,
+          image_id: data.image_id,
         };
         this.authService.setUser(u);
         this.user = u;
-        if (data.has_profile_image) {
-          this.profileImageUrl = `/api/users/${data.id}/profile-image?t=${Date.now()}`;
+        if (data.image_id) {
+          this.profileImageUrl = `/api/images/${data.image_id}?t=${Date.now()}`;
         }
         this.cdr.detectChanges();
       }
@@ -94,21 +95,24 @@ export class UserProfilePage implements OnInit {
       formData.append('image', file);
 
       const res = await fetch('/api/users/me/profile-image', {
-        method: 'PUT',
-        credentials: 'include',
-        body: formData,
+          method: 'PUT',
+          credentials: 'include',
+          body: formData,
       });
 
+      const body = await res.json().catch(() => ({}));
+
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        this.errorMsg.set(body.error || 'Failed to upload image.');
-        return;
+          this.errorMsg.set(body.error || 'Failed to upload image.');
+          return;
       }
 
       // Refresh the image
       if (this.user) {
-        this.profileImageUrl = `/api/users/${this.user.id}/profile-image?t=${Date.now()}`;
+          this.user.image_id = body.image_id;
+          this.profileImageUrl = `/api/images/${this.user.image_id}?t=${Date.now()}`;
       }
+
     } catch {
       this.errorMsg.set('Unable to reach the server.');
     } finally {


### PR DESCRIPTION
Both the listings and users handle image processing and storage independently, which is a bit weird, so I created a unified Image model. 

Backend Changes:
- Update all entities (listings, users, images) to use UUID v7
- Replace `models/listing_image` with `models/image`, using GORM polymorphism to associate w/ users and listings
  - See https://gorm.io/docs/polymorphism.html
- Add simple Image handler/service to get image by ID
  - Removed `listings_handler.go:GetListingImage`
  - Removed `listings_service.go:GetImageByID`
  - Removed `user_handler.go:GetProfileImage`
- Introduced `utils/image.go` for image processing logic used by listing/user services
- Replaced listings/users get image routes with `GET /images/:id -> imageHandler.GetImage`
- Add Image reference to user model and explicit `image_id` response field, replacing boolean `hasProfileImage`
- Add `ImageIDsOnly` preload function to avoid loading blobs when linking images to owner entities
  - Added preloading to relevant users/listings service methods
  - See https://gorm.io/docs/preload.html
- Update `user_service.go:UpdateProfileImage`

Frontend Changes:
- Update CurrentUser interface to accept profile image id
- Update routes to match new API endpoint

Closes #68 